### PR TITLE
fix: use server-provided token expiry instead of hardcoded 1 hour

### DIFF
--- a/internal/cloud/browser_oauth.go
+++ b/internal/cloud/browser_oauth.go
@@ -85,7 +85,7 @@ func BrowserOAuthLogin(client *Client) error {
 			authData = &AuthData{
 				AccessToken:  token,
 				RefreshToken: r.URL.Query().Get("refresh_token"),
-				ExpiresAt:    time.Now().Add(1 * time.Hour),
+				ExpiresAt:    time.Now().Add(365 * 24 * time.Hour),
 			}
 		} else if code := r.URL.Query().Get("code"); code != "" {
 			// OAuth login: exchange code for tokens
@@ -103,7 +103,7 @@ func BrowserOAuthLogin(client *Client) error {
 			authData = &AuthData{
 				AccessToken:  authResp.AccessToken,
 				RefreshToken: authResp.RefreshToken,
-				ExpiresAt:    time.Now().Add(1 * time.Hour),
+				ExpiresAt:    time.Now().Add(365 * 24 * time.Hour),
 				User:         authResp.User,
 			}
 		} else {


### PR DESCRIPTION
- Add ExpiresIn field to AuthResponse struct
- Login/Refresh: use resp.ExpiresIn if > 0, fallback to 365 days
- PollDeviceToken: add 365-day fallback when ExpiresIn is 0
- browser_oauth: use 365-day default instead of 1 hour

Fixes client-side tasks C1/C2 from change spec #46