### PR TITLE
fix: resolve all golangci-lint errors

### DIFF
--- a/cmd/mur/cmd/analytics.go
+++ b/cmd/mur/cmd/analytics.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mur-run/mur-core/internal/core/analytics"
 	"github.com/spf13/cobra"
+
+	"github.com/mur-run/mur-core/internal/core/analytics"
 )
 
 var analyticsCmd = &cobra.Command{

--- a/cmd/mur/cmd/audit.go
+++ b/cmd/mur/cmd/audit.go
@@ -3,8 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/mur-run/mur-core/internal/core/audit"
 	"github.com/spf13/cobra"
+
+	"github.com/mur-run/mur-core/internal/core/audit"
 )
 
 var auditCmd = &cobra.Command{

--- a/cmd/mur/cmd/classify.go
+++ b/cmd/mur/cmd/classify.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/mur-run/mur-core/internal/core/classifier"
 	"github.com/mur-run/mur-core/internal/core/pattern"
-	"github.com/spf13/cobra"
 )
 
 var classifyCmd = &cobra.Command{

--- a/cmd/mur/cmd/clean.go
+++ b/cmd/mur/cmd/clean.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mur-run/mur-core/internal/sync"
 	"github.com/spf13/cobra"
+
+	"github.com/mur-run/mur-core/internal/sync"
 )
 
 var cleanCmd = &cobra.Command{
@@ -225,7 +226,7 @@ func cleanDirectory(dir string, days int, label string, force bool) (int64, int)
 
 	cutoff := time.Now().AddDate(0, 0, -days)
 
-	filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() {
 			return nil
 		}

--- a/cmd/mur/cmd/cloud.go
+++ b/cmd/mur/cmd/cloud.go
@@ -6,11 +6,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
 	"github.com/mur-run/mur-core/internal/cloud"
 	"github.com/mur-run/mur-core/internal/config"
 	"github.com/mur-run/mur-core/internal/core/pattern"
-	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 var cloudCmd = &cobra.Command{
@@ -358,9 +359,9 @@ Examples:
 							if resolutions[c.PatternName] == ResolutionKeepServer && c.ServerVersion != nil {
 								localP := convertCloudPattern(c.ServerVersion)
 								if store.Exists(localP.Name) {
-									store.Update(localP)
+									_ = store.Update(localP)
 								} else {
-									store.Create(localP)
+									_ = store.Create(localP)
 								}
 							}
 						}
@@ -427,13 +428,13 @@ func saveLocalSyncVersion(teamSlug string, version int64) {
 	// Load existing state
 	data, err := os.ReadFile(path)
 	if err == nil {
-		yaml.Unmarshal(data, &state)
+		_ = yaml.Unmarshal(data, &state)
 	}
 
 	state[teamSlug] = version
 
 	data, _ = yaml.Marshal(state)
-	os.WriteFile(path, data, 0644)
+	_ = os.WriteFile(path, data, 0644)
 }
 
 func convertCloudPattern(p *cloud.Pattern) *pattern.Pattern {

--- a/cmd/mur/cmd/collection.go
+++ b/cmd/mur/cmd/collection.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/mur-run/mur-core/internal/cloud"
 	"github.com/spf13/cobra"
+
+	"github.com/mur-run/mur-core/internal/cloud"
 )
 
 var collectionCmd = &cobra.Command{

--- a/cmd/mur/cmd/community.go
+++ b/cmd/mur/cmd/community.go
@@ -7,11 +7,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/mur-run/mur-core/internal/cloud"
 	"github.com/mur-run/mur-core/internal/config"
 	"github.com/mur-run/mur-core/internal/core/pattern"
 	"github.com/mur-run/mur-core/internal/security"
-	"github.com/spf13/cobra"
 )
 
 var communityCmd = &cobra.Command{
@@ -530,13 +531,13 @@ func runCommunityShare(cmd *cobra.Command, args []string) error {
 		}
 		if pattern.NeedsTranslation(localPattern) {
 			fmt.Println("🌐 Detected non-English content, translating...")
-			
+
 			translateReq := &cloud.TranslatePatternRequest{
 				Name:        targetPattern.Name,
 				Description: targetPattern.Description,
 				Content:     targetPattern.Content,
 			}
-			
+
 			translated, err := client.TranslatePattern(translateReq)
 			if err != nil {
 				fmt.Printf("⚠️  Translation failed: %v\n", err)

--- a/cmd/mur/cmd/conflict.go
+++ b/cmd/mur/cmd/conflict.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
+
 	"github.com/mur-run/mur-core/internal/cloud"
 )
 
@@ -145,13 +146,6 @@ func resolveConflictInteractive(c cloud.Conflict, index, total int) (ConflictRes
 
 func formatPatternInfo(p *cloud.Pattern, label string) string {
 	var sb strings.Builder
-
-	// Get content preview (first 100 chars)
-	preview := p.Content
-	if len(preview) > 100 {
-		preview = preview[:100] + "..."
-	}
-	preview = strings.ReplaceAll(preview, "\n", " ")
 
 	lines := strings.Count(p.Content, "\n") + 1
 

--- a/cmd/mur/cmd/context.go
+++ b/cmd/mur/cmd/context.go
@@ -6,10 +6,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/mur-run/mur-core/internal/core/embed"
 	"github.com/mur-run/mur-core/internal/core/inject"
 	"github.com/mur-run/mur-core/internal/core/pattern"
-	"github.com/spf13/cobra"
 )
 
 var contextCmd = &cobra.Command{

--- a/cmd/mur/cmd/cross_learn.go
+++ b/cmd/mur/cmd/cross_learn.go
@@ -6,10 +6,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/mur-run/mur-core/internal/core/pattern"
 	"github.com/mur-run/mur-core/internal/core/suggest"
 	"github.com/mur-run/mur-core/internal/learn"
-	"github.com/spf13/cobra"
 )
 
 var crossLearnCmd = &cobra.Command{

--- a/cmd/mur/cmd/dashboard.go
+++ b/cmd/mur/cmd/dashboard.go
@@ -8,9 +8,10 @@ import (
 	"sort"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/mur-run/mur-core/internal/core/pattern"
 	"github.com/mur-run/mur-core/internal/stats"
-	"github.com/spf13/cobra"
 )
 
 var dashboardCmd = &cobra.Command{
@@ -56,10 +57,10 @@ func runDashboard(cmd *cobra.Command, args []string) error {
 	data := buildStaticDashboardData(patterns)
 
 	funcMap := template.FuncMap{
-		"mul": func(a, b float64) float64 { return a * b },
-		"sub": func(a, b float64) float64 { return a - b },
-		"gt0": func(a float64) bool { return a > 0 },
-		"lt":  func(a, b float64) bool { return a < b },
+		"mul":    func(a, b float64) float64 { return a * b },
+		"sub":    func(a, b float64) float64 { return a - b },
+		"gt0":    func(a float64) bool { return a > 0 },
+		"lt":     func(a, b float64) bool { return a < b },
 		"printf": fmt.Sprintf,
 	}
 

--- a/cmd/mur/cmd/devices.go
+++ b/cmd/mur/cmd/devices.go
@@ -5,8 +5,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mur-run/mur-core/internal/cloud"
 	"github.com/spf13/cobra"
+
+	"github.com/mur-run/mur-core/internal/cloud"
 )
 
 var devicesCmd = &cobra.Command{

--- a/cmd/mur/cmd/doctor.go
+++ b/cmd/mur/cmd/doctor.go
@@ -9,9 +9,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/mur-run/mur-core/internal/config"
 	murhooks "github.com/mur-run/mur-core/internal/hooks"
-	"github.com/spf13/cobra"
 )
 
 var doctorCmd = &cobra.Command{
@@ -341,7 +342,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	// Check 9: Premium LLM configuration
 	if cfg != nil && cfg.Learning.LLM.Premium != nil {
 		p := cfg.Learning.LLM.Premium
-		msg := fmt.Sprintf("%s", p.Provider)
+		msg := string(p.Provider)
 		if p.Model != "" {
 			msg += "/" + p.Model
 		}

--- a/cmd/mur/cmd/embed.go
+++ b/cmd/mur/cmd/embed.go
@@ -5,9 +5,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/spf13/cobra"
+
 	"github.com/mur-run/mur-core/internal/core/embed"
 	"github.com/mur-run/mur-core/internal/core/pattern"
-	"github.com/spf13/cobra"
 )
 
 var embedCmd = &cobra.Command{
@@ -112,7 +113,7 @@ func embedStatusExecute(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Provider:   %s\n", status.Provider)
 	fmt.Printf("Dimension:  %d\n", status.Dimension)
 	fmt.Printf("Patterns:   %d total\n", status.TotalPatterns)
-	fmt.Printf("Indexed:    %d (%.0f%%)\n", status.Indexed, 
+	fmt.Printf("Indexed:    %d (%.0f%%)\n", status.Indexed,
 		float64(status.Indexed)/float64(max(status.TotalPatterns, 1))*100)
 
 	if status.Indexed < status.TotalPatterns {

--- a/cmd/mur/cmd/export.go
+++ b/cmd/mur/cmd/export.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/mur-run/mur-core/internal/core/pattern"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
+
+	"github.com/mur-run/mur-core/internal/core/pattern"
 )
 
 var exportCmd = &cobra.Command{
@@ -27,11 +28,11 @@ Examples:
 }
 
 var (
-	exportFormat         string
-	exportOutput         string
-	exportTag            string
+	exportFormat           string
+	exportOutput           string
+	exportTag              string
 	exportMinEffectiveness float64
-	exportIncludeArchived bool
+	exportIncludeArchived  bool
 )
 
 func init() {
@@ -132,9 +133,7 @@ func formatMarkdown(patterns []pattern.Pattern) string {
 
 		// Tags
 		var tags []string
-		for _, t := range p.Tags.Confirmed {
-			tags = append(tags, t)
-		}
+		tags = append(tags, p.Tags.Confirmed...)
 		for _, ts := range p.Tags.Inferred {
 			if ts.Confidence >= 0.5 {
 				tags = append(tags, fmt.Sprintf("%s (%.0f%%)", ts.Tag, ts.Confidence*100))

--- a/cmd/mur/cmd/feedback.go
+++ b/cmd/mur/cmd/feedback.go
@@ -7,8 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/mur-run/mur-core/internal/analytics"
 	"github.com/spf13/cobra"
+
+	"github.com/mur-run/mur-core/internal/analytics"
 )
 
 var feedbackCmd = &cobra.Command{

--- a/cmd/mur/cmd/import.go
+++ b/cmd/mur/cmd/import.go
@@ -3,17 +3,17 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 
-	"github.com/mur-run/mur-core/internal/config"
-	"github.com/mur-run/mur-core/internal/core/pattern"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
+
+	"github.com/mur-run/mur-core/internal/config"
+	"github.com/mur-run/mur-core/internal/core/pattern"
 )
 
 var importCmd = &cobra.Command{
@@ -54,11 +54,11 @@ func init() {
 
 // GistResponse represents GitHub Gist API response
 type GistResponse struct {
-	ID          string               `json:"id"`
-	Description string               `json:"description"`
-	Files       map[string]GistFile  `json:"files"`
-	Owner       *GistOwner           `json:"owner"`
-	HTMLURL     string               `json:"html_url"`
+	ID          string              `json:"id"`
+	Description string              `json:"description"`
+	Files       map[string]GistFile `json:"files"`
+	Owner       *GistOwner          `json:"owner"`
+	HTMLURL     string              `json:"html_url"`
 }
 
 type GistFile struct {
@@ -141,7 +141,7 @@ func runImportGist(cmd *cobra.Command, args []string) error {
 func extractGistID(input string) string {
 	// Full URL: https://gist.github.com/user/abc123
 	// Or just: abc123
-	
+
 	re := regexp.MustCompile(`gist\.github\.com/[^/]+/([a-f0-9]+)`)
 	if matches := re.FindStringSubmatch(input); len(matches) > 1 {
 		return matches[1]
@@ -214,7 +214,7 @@ func constructPatternFromFiles(gist *GistResponse) (*pattern.Pattern, error) {
 
 	for filename, file := range gist.Files {
 		lower := strings.ToLower(filename)
-		
+
 		if strings.HasPrefix(lower, "readme") {
 			readmeContent = file.Content
 			continue
@@ -280,20 +280,4 @@ func constructPatternFromFiles(gist *GistResponse) (*pattern.Pattern, error) {
 	}
 
 	return p, nil
-}
-
-// fetchRawContent fetches raw content from a URL
-func fetchRawContent(url string) (string, error) {
-	resp, err := http.Get(url)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
-	return string(body), nil
 }

--- a/cmd/mur/cmd/index.go
+++ b/cmd/mur/cmd/index.go
@@ -5,9 +5,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/mur-run/mur-core/internal/config"
 	"github.com/mur-run/mur-core/internal/core/embed"
-	"github.com/spf13/cobra"
 )
 
 var indexCmd = &cobra.Command{

--- a/cmd/mur/cmd/init.go
+++ b/cmd/mur/cmd/init.go
@@ -10,10 +10,11 @@ import (
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/spf13/cobra"
+
 	"github.com/mur-run/mur-core/internal/config"
 	murhooks "github.com/mur-run/mur-core/internal/hooks"
 	"github.com/mur-run/mur-core/internal/sync"
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -48,9 +49,9 @@ func init() {
 
 // CLI tool configuration
 type cliTool struct {
-	Name       string
-	Binary     string
-	Installed  bool
+	Name         string
+	Binary       string
+	Installed    bool
 	HooksSupport bool
 }
 
@@ -504,9 +505,9 @@ mur sync --quiet 2>/dev/null || true
 
 	var settings map[string]interface{}
 	if data, err := os.ReadFile(claudeSettingsPath); err == nil {
-		json.Unmarshal(data, &settings)
+		_ = json.Unmarshal(data, &settings)
 	} else {
-		os.MkdirAll(filepath.Join(home, ".claude"), 0755)
+		_ = os.MkdirAll(filepath.Join(home, ".claude"), 0755)
 		settings = make(map[string]interface{})
 	}
 
@@ -514,7 +515,7 @@ mur sync --quiet 2>/dev/null || true
 	if _, err := os.Stat(claudeSettingsPath); err == nil {
 		backupPath := claudeSettingsPath + ".backup"
 		if data, err := os.ReadFile(claudeSettingsPath); err == nil {
-			os.WriteFile(backupPath, data, 0644)
+			_ = os.WriteFile(backupPath, data, 0644)
 		}
 	}
 
@@ -563,9 +564,9 @@ func installGeminiHooks(home, promptScriptPath, stopScriptPath string) error {
 
 	var settings map[string]interface{}
 	if data, err := os.ReadFile(geminiSettingsPath); err == nil {
-		json.Unmarshal(data, &settings)
+		_ = json.Unmarshal(data, &settings)
 	} else {
-		os.MkdirAll(filepath.Join(home, ".gemini"), 0755)
+		_ = os.MkdirAll(filepath.Join(home, ".gemini"), 0755)
 		settings = make(map[string]interface{})
 	}
 
@@ -573,7 +574,7 @@ func installGeminiHooks(home, promptScriptPath, stopScriptPath string) error {
 	if _, err := os.Stat(geminiSettingsPath); err == nil {
 		backupPath := geminiSettingsPath + ".backup"
 		if data, err := os.ReadFile(geminiSettingsPath); err == nil {
-			os.WriteFile(backupPath, data, 0644)
+			_ = os.WriteFile(backupPath, data, 0644)
 		}
 	}
 

--- a/cmd/mur/cmd/inject.go
+++ b/cmd/mur/cmd/inject.go
@@ -7,8 +7,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/mur-run/mur-core/internal/core/pattern"
 	"github.com/spf13/cobra"
+
+	"github.com/mur-run/mur-core/internal/core/pattern"
 )
 
 var injectCmd = &cobra.Command{
@@ -31,11 +32,11 @@ Examples:
 }
 
 var (
-	injectFile            string
-	injectTag             string
+	injectFile             string
+	injectTag              string
 	injectMinEffectiveness float64
-	injectDryRun          bool
-	injectAppend          bool
+	injectDryRun           bool
+	injectAppend           bool
 )
 
 func init() {

--- a/cmd/mur/cmd/learn.go
+++ b/cmd/mur/cmd/learn.go
@@ -7,11 +7,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/mur-run/mur-core/internal/config"
 	"github.com/mur-run/mur-core/internal/learn"
 	"github.com/mur-run/mur-core/internal/learning"
 	"github.com/mur-run/mur-core/internal/notify"
-	"github.com/spf13/cobra"
 )
 
 var learnCmd = &cobra.Command{

--- a/cmd/mur/cmd/lifecycle.go
+++ b/cmd/mur/cmd/lifecycle.go
@@ -6,8 +6,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/mur-run/mur-core/internal/core/pattern"
 	"github.com/spf13/cobra"
+
+	"github.com/mur-run/mur-core/internal/core/pattern"
 )
 
 var lifecycleCmd = &cobra.Command{
@@ -84,7 +85,7 @@ func getLifecycleManager() (*pattern.LifecycleManager, error) {
 
 func lifecycleEvaluateExecute(cmd *cobra.Command, args []string) error {
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
-	
+
 	home, _ := os.UserHomeDir()
 	patternsDir := filepath.Join(home, ".mur", "patterns")
 	store := pattern.NewStore(patternsDir)

--- a/cmd/mur/cmd/lint.go
+++ b/cmd/mur/cmd/lint.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/mur-run/mur-core/internal/core/pattern"
 	"github.com/spf13/cobra"
+
+	"github.com/mur-run/mur-core/internal/core/pattern"
 )
 
 var lintCmd = &cobra.Command{

--- a/cmd/mur/cmd/login.go
+++ b/cmd/mur/cmd/login.go
@@ -8,10 +8,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/mur-run/mur-core/internal/cloud"
-	"github.com/mur-run/mur-core/internal/config"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
+
+	"github.com/mur-run/mur-core/internal/cloud"
+	"github.com/mur-run/mur-core/internal/config"
 )
 
 var loginCmd = &cobra.Command{

--- a/cmd/mur/cmd/migrate.go
+++ b/cmd/mur/cmd/migrate.go
@@ -3,8 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/mur-run/mur-core/internal/core/pattern"
 	"github.com/spf13/cobra"
+
+	"github.com/mur-run/mur-core/internal/core/pattern"
 )
 
 var migrateCmd = &cobra.Command{

--- a/cmd/mur/cmd/new.go
+++ b/cmd/mur/cmd/new.go
@@ -126,7 +126,7 @@ schema_version: 2
 		editorCmd.Stdin = os.Stdin
 		editorCmd.Stdout = os.Stdout
 		editorCmd.Stderr = os.Stderr
-		editorCmd.Run()
+		_ = editorCmd.Run()
 	}
 
 	fmt.Println()

--- a/cmd/mur/cmd/notify.go
+++ b/cmd/mur/cmd/notify.go
@@ -3,9 +3,10 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/mur-run/mur-core/internal/config"
 	"github.com/mur-run/mur-core/internal/notify"
-	"github.com/spf13/cobra"
 )
 
 var notifyCmd = &cobra.Command{

--- a/cmd/mur/cmd/output.go
+++ b/cmd/mur/cmd/output.go
@@ -5,17 +5,18 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/mur-run/mur-core/internal/learn"
 	"github.com/mur-run/mur-core/internal/stats"
 	"github.com/mur-run/mur-core/internal/sync"
-	"github.com/spf13/cobra"
 )
 
 // OutputStatus represents the full status output
 type OutputStatus struct {
-	Version   string        `json:"version"`
-	Timestamp string        `json:"timestamp"`
-	Stats     *stats.Summary `json:"stats,omitempty"`
+	Version   string          `json:"version"`
+	Timestamp string          `json:"timestamp"`
+	Stats     *stats.Summary  `json:"stats,omitempty"`
 	Patterns  []learn.Pattern `json:"patterns,omitempty"`
 }
 

--- a/cmd/mur/cmd/preview.go
+++ b/cmd/mur/cmd/preview.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/mur-run/mur-core/internal/core/pattern"
 	"github.com/mur-run/mur-core/internal/security"
-	"github.com/spf13/cobra"
 )
 
 var previewCmd = &cobra.Command{

--- a/cmd/mur/cmd/referral.go
+++ b/cmd/mur/cmd/referral.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/mur-run/mur-core/internal/cloud"
 	"github.com/spf13/cobra"
+
+	"github.com/mur-run/mur-core/internal/cloud"
 )
 
 var referralCmd = &cobra.Command{

--- a/cmd/mur/cmd/rehash.go
+++ b/cmd/mur/cmd/rehash.go
@@ -3,8 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/mur-run/mur-core/internal/core/pattern"
 	"github.com/spf13/cobra"
+
+	"github.com/mur-run/mur-core/internal/core/pattern"
 )
 
 var rehashCmd = &cobra.Command{

--- a/cmd/mur/cmd/repo.go
+++ b/cmd/mur/cmd/repo.go
@@ -85,13 +85,13 @@ func runRepoSet(cmd *cobra.Command, args []string) error {
 			if err := cmd.Run(); err != nil {
 				// Try adding remote instead
 				cmd = exec.Command("git", "-C", patternsDir, "remote", "add", "origin", repoURL)
-				cmd.Run()
+				_ = cmd.Run()
 			}
 		} else {
 			// Has content but not a git repo - backup and clone
 			backupDir := patternsDir + ".backup"
 			fmt.Printf("Backing up existing patterns to %s\n", backupDir)
-			os.Rename(patternsDir, backupDir)
+			_ = os.Rename(patternsDir, backupDir)
 
 			// Clone new repo
 			fmt.Println("Cloning repository...")
@@ -100,13 +100,13 @@ func runRepoSet(cmd *cobra.Command, args []string) error {
 			cmd.Stderr = os.Stderr
 			if err := cmd.Run(); err != nil {
 				// Restore backup on failure
-				os.Rename(backupDir, patternsDir)
+				_ = os.Rename(backupDir, patternsDir)
 				return fmt.Errorf("failed to clone: %w", err)
 			}
 		}
 	} else {
 		// Empty or doesn't exist - just clone
-		os.MkdirAll(filepath.Dir(patternsDir), 0755)
+		_ = os.MkdirAll(filepath.Dir(patternsDir), 0755)
 		fmt.Println("Cloning repository...")
 		cmd := exec.Command("git", "clone", repoURL, patternsDir)
 		cmd.Stdout = os.Stdout
@@ -173,7 +173,7 @@ func runRepoStatus(cmd *cobra.Command, args []string) error {
 
 	// Count patterns
 	count := 0
-	filepath.Walk(patternsDir, func(path string, info os.FileInfo, err error) error {
+	_ = filepath.Walk(patternsDir, func(path string, info os.FileInfo, err error) error {
 		if err == nil && !info.IsDir() && strings.HasSuffix(path, ".yaml") {
 			count++
 		}
@@ -218,7 +218,7 @@ func runRepoRemove(cmd *cobra.Command, args []string) error {
 	}
 
 	// Remove from config
-	saveRepoConfig(home, "")
+	_ = saveRepoConfig(home, "")
 
 	fmt.Println("✅ Learning repo removed. Patterns are still available locally.")
 
@@ -292,7 +292,7 @@ func SetupLearningRepo(home string) error {
 
 	// Clone the repo
 	patternsDir := filepath.Join(home, ".mur", "repo")
-	os.MkdirAll(filepath.Dir(patternsDir), 0755)
+	_ = os.MkdirAll(filepath.Dir(patternsDir), 0755)
 
 	fmt.Println("  Cloning repository...")
 	cmd := exec.Command("git", "clone", repoURL, patternsDir)
@@ -302,7 +302,7 @@ func SetupLearningRepo(home string) error {
 	}
 
 	// Save to config
-	saveRepoConfig(home, repoURL)
+	_ = saveRepoConfig(home, repoURL)
 
 	fmt.Println("  ✓ Learning repo configured")
 	return nil

--- a/cmd/mur/cmd/run.go
+++ b/cmd/mur/cmd/run.go
@@ -7,13 +7,14 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/mur-run/mur-core/internal/config"
 	"github.com/mur-run/mur-core/internal/core/embed"
 	"github.com/mur-run/mur-core/internal/core/inject"
 	"github.com/mur-run/mur-core/internal/core/pattern"
 	"github.com/mur-run/mur-core/internal/router"
 	"github.com/mur-run/mur-core/internal/stats"
-	"github.com/spf13/cobra"
 )
 
 var runCmd = &cobra.Command{
@@ -93,8 +94,8 @@ func runExecute(cmd *cobra.Command, args []string) error {
 					fmt.Printf("   • %s\n", p.Name)
 				}
 				if injectionResult.Context != nil && injectionResult.Context.ProjectType != "" {
-					fmt.Printf("🔍 Context: %s project (%s)\n", 
-						injectionResult.Context.ProjectType, 
+					fmt.Printf("🔍 Context: %s project (%s)\n",
+						injectionResult.Context.ProjectType,
 						injectionResult.Context.ProjectName)
 				}
 				fmt.Println()

--- a/cmd/mur/cmd/search.go
+++ b/cmd/mur/cmd/search.go
@@ -7,12 +7,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/mur-run/mur-core/internal/cache"
 	"github.com/mur-run/mur-core/internal/cloud"
 	"github.com/mur-run/mur-core/internal/config"
 	"github.com/mur-run/mur-core/internal/core/analytics"
 	"github.com/mur-run/mur-core/internal/core/embed"
-	"github.com/spf13/cobra"
 )
 
 var searchCmd = &cobra.Command{
@@ -35,12 +36,12 @@ Examples:
 }
 
 var (
-	searchTopK         int
-	searchJSON         bool
-	searchInject       bool
-	searchCommunity    bool
+	searchTopK          int
+	searchJSON          bool
+	searchInject        bool
+	searchCommunity     bool
 	searchCommunityOnly bool
-	searchLocalOnly    bool
+	searchLocalOnly     bool
 )
 
 func init() {
@@ -279,7 +280,7 @@ func cacheCommunityPatterns(cfg *config.Config, patterns []cloud.CommunityPatter
 		}
 
 		// Cache it
-		communityCache.Save(&cache.CachedPattern{
+		_ = communityCache.Save(&cache.CachedPattern{
 			ID:          detail.ID,
 			Name:        detail.Name,
 			Description: detail.Description,

--- a/cmd/mur/cmd/serve.go
+++ b/cmd/mur/cmd/serve.go
@@ -12,9 +12,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/mur-run/mur-core/internal/core/pattern"
 	"github.com/mur-run/mur-core/internal/stats"
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -56,14 +57,14 @@ type DashboardData struct {
 	RecentPatterns []PatternView
 
 	// Usage Stats
-	TotalUsage      int
-	TotalRuns       int
-	AvgEffective    float64
-	EstimatedCost   float64
-	EstimatedSaved  float64
-	DailyTrend      []DailyPoint
-	ToolBreakdown   []ToolUsage
-	AutoRouteStats  AutoRouteView
+	TotalUsage     int
+	TotalRuns      int
+	AvgEffective   float64
+	EstimatedCost  float64
+	EstimatedSaved float64
+	DailyTrend     []DailyPoint
+	ToolBreakdown  []ToolUsage
+	AutoRouteStats AutoRouteView
 
 	// Sync Status
 	SyncTargets []SyncTarget
@@ -221,7 +222,7 @@ func servePatterns(w http.ResponseWriter, r *http.Request, store *pattern.Store)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(views)
+	_ = json.NewEncoder(w).Encode(views)
 }
 
 func servePatternDetail(w http.ResponseWriter, r *http.Request, store *pattern.Store) {
@@ -238,7 +239,7 @@ func servePatternDetail(w http.ResponseWriter, r *http.Request, store *pattern.S
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(p)
+	_ = json.NewEncoder(w).Encode(p)
 }
 
 func serveStats(w http.ResponseWriter, r *http.Request, store *pattern.Store) {
@@ -251,7 +252,7 @@ func serveStats(w http.ResponseWriter, r *http.Request, store *pattern.Store) {
 	data := buildDashboardData(patterns)
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(data)
+	_ = json.NewEncoder(w).Encode(data)
 }
 
 func handleSyncAction(w http.ResponseWriter, r *http.Request) {
@@ -269,7 +270,7 @@ func handleSyncAction(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(result)
+	_ = json.NewEncoder(w).Encode(result)
 }
 
 func buildDashboardData(patterns []pattern.Pattern) DashboardData {
@@ -378,7 +379,7 @@ func buildDashboardData(patterns []pattern.Pattern) DashboardData {
 
 func getSyncTargets() []SyncTarget {
 	home, _ := os.UserHomeDir()
-	
+
 	// Strict tool detection: check for actual binaries or app bundles
 	claudeInstalled := commandExists("claude") || fileExists(filepath.Join(home, ".npm-global", "bin", "claude"))
 	geminiInstalled := commandExists("gemini") || fileExists(filepath.Join(home, ".npm-global", "bin", "gemini"))
@@ -389,7 +390,7 @@ func getSyncTargets() []SyncTarget {
 	cursorInstalled := fileExists("/Applications/Cursor.app") || fileExists(filepath.Join(home, "Applications", "Cursor.app"))
 	windsurfInstalled := fileExists("/Applications/Windsurf.app") || fileExists(filepath.Join(home, "Applications", "Windsurf.app"))
 	continueInstalled := fileExists(filepath.Join(home, ".continue", "config.json"))
-	
+
 	targets := []SyncTarget{
 		// CLIs
 		{Name: "Claude Code", Type: "cli", Path: filepath.Join(home, ".claude", "skills", "mur-index"), Installed: claudeInstalled},
@@ -495,7 +496,7 @@ func openBrowser(url string) {
 
 	go func() {
 		execCmd := exec.Command(cmd, args...)
-		execCmd.Run()
+		_ = execCmd.Run()
 	}()
 }
 

--- a/cmd/mur/cmd/skills.go
+++ b/cmd/mur/cmd/skills.go
@@ -5,8 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/mur-run/mur-core/internal/sync"
 	"github.com/spf13/cobra"
+
+	"github.com/mur-run/mur-core/internal/sync"
 )
 
 var skillsCmd = &cobra.Command{

--- a/cmd/mur/cmd/stats.go
+++ b/cmd/mur/cmd/stats.go
@@ -8,8 +8,9 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/mur-run/mur-core/internal/analytics"
 	"github.com/spf13/cobra"
+
+	"github.com/mur-run/mur-core/internal/analytics"
 )
 
 var statsCmd = &cobra.Command{

--- a/cmd/mur/cmd/status.go
+++ b/cmd/mur/cmd/status.go
@@ -7,11 +7,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/mur-run/mur-core/internal/cloud"
 	"github.com/mur-run/mur-core/internal/config"
 	"github.com/mur-run/mur-core/internal/core/pattern"
 	"github.com/mur-run/mur-core/internal/stats"
-	"github.com/spf13/cobra"
 )
 
 var statusCmd = &cobra.Command{

--- a/cmd/mur/cmd/suggest.go
+++ b/cmd/mur/cmd/suggest.go
@@ -7,9 +7,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/mur-run/mur-core/internal/core/pattern"
 	"github.com/mur-run/mur-core/internal/core/suggest"
-	"github.com/spf13/cobra"
 )
 
 var suggestCmd = &cobra.Command{

--- a/cmd/mur/cmd/sync.go
+++ b/cmd/mur/cmd/sync.go
@@ -7,13 +7,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/mur-run/mur-core/internal/cache"
 	"github.com/mur-run/mur-core/internal/cloud"
 	"github.com/mur-run/mur-core/internal/config"
 	"github.com/mur-run/mur-core/internal/learn"
 	"github.com/mur-run/mur-core/internal/security"
 	"github.com/mur-run/mur-core/internal/sync"
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -123,7 +124,6 @@ func runSync(cmd *cobra.Command, args []string) error {
 
 		// If neither cloud nor git, just sync to CLIs
 		if !useCloud && !useGit {
-			cliOnly = true
 			if !syncQuiet {
 				fmt.Println("💻 Syncing to local CLIs only")
 				fmt.Println()
@@ -233,7 +233,7 @@ func runCloudSync(cmd *cobra.Command, cfg *config.Config) error {
 
 	// Execute cloud sync by calling the cloud sync function directly
 	// Reuse cloudSyncCmd logic
-	cmd.Flags().Set("team", teamSlug)
+	_ = cmd.Flags().Set("team", teamSlug)
 	return cloudSyncCmd.RunE(cmd, []string{})
 }
 
@@ -271,12 +271,12 @@ func runGitSync(home string, cfg *config.Config) error {
 		}
 
 		addCmd := exec.Command("git", "-C", patternsDir, "add", "-A")
-		addCmd.Run()
+		_ = addCmd.Run()
 
 		diffCmd := exec.Command("git", "-C", patternsDir, "diff", "--cached", "--quiet")
 		if diffCmd.Run() != nil {
 			commitCmd := exec.Command("git", "-C", patternsDir, "commit", "-m", "mur: sync patterns")
-			commitCmd.Run()
+			_ = commitCmd.Run()
 		}
 
 		pushCmd := exec.Command("git", "-C", patternsDir, "push")

--- a/cmd/mur/cmd/team.go
+++ b/cmd/mur/cmd/team.go
@@ -3,8 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/mur-run/mur-core/internal/team"
 	"github.com/spf13/cobra"
+
+	"github.com/mur-run/mur-core/internal/team"
 )
 
 var teamCmd = &cobra.Command{

--- a/cmd/mur/cmd/update.go
+++ b/cmd/mur/cmd/update.go
@@ -7,8 +7,9 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/mur-run/mur-core/internal/config"
 	"github.com/spf13/cobra"
+
+	"github.com/mur-run/mur-core/internal/config"
 )
 
 var updateCmd = &cobra.Command{
@@ -126,7 +127,7 @@ func init() {
 func updateBinary() error {
 	// Detect installation method by checking binary path
 	installMethod := detectInstallMethod()
-	
+
 	var cmd *exec.Cmd
 	switch installMethod {
 	case "homebrew":
@@ -134,7 +135,7 @@ func updateBinary() error {
 		// Update tap first to ensure we have the latest formula
 		fmt.Println("  ↻ Updating tap...")
 		updateTap := exec.Command("brew", "update", "mur-run/tap")
-		updateTap.Run() // Ignore errors, upgrade will still work with cached version
+		_ = updateTap.Run() // Ignore errors, upgrade will still work with cached version
 		cmd = exec.Command("brew", "upgrade", "mur")
 	case "go":
 		fmt.Println("  🐹 Detected Go installation")
@@ -143,7 +144,7 @@ func updateBinary() error {
 		fmt.Println("  🐹 Using Go install (default)")
 		cmd = exec.Command("go", "install", "github.com/mur-run/mur-core/cmd/mur@latest")
 	}
-	
+
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
@@ -152,8 +153,8 @@ func updateBinary() error {
 		if installMethod == "homebrew" {
 			fmt.Println("  ℹ️  Running brew update first...")
 			updateCmd := exec.Command("brew", "update")
-			updateCmd.Run()
-			
+			_ = updateCmd.Run()
+
 			// Retry upgrade
 			retryCmd := exec.Command("brew", "upgrade", "mur")
 			retryCmd.Stdout = os.Stdout
@@ -178,39 +179,39 @@ func detectInstallMethod() string {
 	if err != nil {
 		return "unknown"
 	}
-	
+
 	// Resolve symlinks to get the real path
 	realPath, err := filepath.EvalSymlinks(exePath)
 	if err != nil {
 		realPath = exePath
 	}
-	
+
 	// Check for Homebrew paths
 	homebrewPaths := []string{
-		"/opt/homebrew/",      // Apple Silicon
-		"/usr/local/Cellar/",  // Intel Mac
-		"/home/linuxbrew/",    // Linux Homebrew
+		"/opt/homebrew/",     // Apple Silicon
+		"/usr/local/Cellar/", // Intel Mac
+		"/home/linuxbrew/",   // Linux Homebrew
 	}
-	
+
 	for _, prefix := range homebrewPaths {
 		if len(realPath) >= len(prefix) && realPath[:len(prefix)] == prefix {
 			return "homebrew"
 		}
 	}
-	
+
 	// Check for Go bin paths
 	home, _ := os.UserHomeDir()
 	goPaths := []string{
 		filepath.Join(home, "go", "bin"),
 		"/usr/local/go/bin",
 	}
-	
+
 	for _, goPath := range goPaths {
 		if len(realPath) >= len(goPath) && realPath[:len(goPath)] == goPath {
 			return "go"
 		}
 	}
-	
+
 	// Check GOPATH/bin
 	if gopath := os.Getenv("GOPATH"); gopath != "" {
 		gopathBin := filepath.Join(gopath, "bin")
@@ -218,7 +219,7 @@ func detectInstallMethod() string {
 			return "go"
 		}
 	}
-	
+
 	return "unknown"
 }
 

--- a/cmd/mur/cmd/verify.go
+++ b/cmd/mur/cmd/verify.go
@@ -3,9 +3,10 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/mur-run/mur-core/internal/core/pattern"
 	"github.com/mur-run/mur-core/internal/security"
-	"github.com/spf13/cobra"
 )
 
 var verifyCmd = &cobra.Command{

--- a/internal/analytics/store.go
+++ b/internal/analytics/store.go
@@ -38,14 +38,14 @@ type FeedbackEvent struct {
 
 // PatternStats holds aggregated stats for a pattern.
 type PatternStats struct {
-	PatternID      string
-	PatternName    string
-	UsageCount     int
-	HelpfulCount   int
+	PatternID       string
+	PatternName     string
+	UsageCount      int
+	HelpfulCount    int
 	NotHelpfulCount int
-	SkipCount      int
-	Effectiveness  float64 // helpful / (helpful + not_helpful)
-	LastUsed       *time.Time
+	SkipCount       int
+	Effectiveness   float64 // helpful / (helpful + not_helpful)
+	LastUsed        *time.Time
 }
 
 // DailyStats holds daily aggregates.
@@ -60,7 +60,7 @@ type DailyStats struct {
 // NewStore creates a new analytics store.
 func NewStore(dataDir string) (*Store, error) {
 	dbPath := filepath.Join(dataDir, "analytics.db")
-	
+
 	// Ensure directory exists
 	if err := os.MkdirAll(dataDir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create data directory: %w", err)

--- a/internal/cache/community.go
+++ b/internal/cache/community.go
@@ -52,7 +52,7 @@ func NewCommunityCache(baseDir string, ttlDays, maxSizeMB int) *CommunityCache {
 	}
 
 	dir := filepath.Join(baseDir, "cache", "community")
-	os.MkdirAll(dir, 0755)
+	_ = os.MkdirAll(dir, 0755)
 
 	return &CommunityCache{
 		dir:       dir,
@@ -88,7 +88,7 @@ func (c *CommunityCache) Get(id string) (*CachedPattern, error) {
 
 	// Update last used
 	pattern.LastUsed = time.Now()
-	c.Save(&pattern)
+	_ = c.Save(&pattern)
 
 	return &pattern, nil
 }
@@ -205,7 +205,7 @@ func (c *CommunityCache) Cleanup() (int, error) {
 		}
 	}
 
-	c.saveMeta(meta)
+	_ = c.saveMeta(meta)
 	return removed, nil
 }
 
@@ -230,7 +230,7 @@ func (c *CommunityCache) cleanupIfNeeded() {
 
 	// Cleanup if over 90% of limit or > 1000 patterns
 	if sizeKB > maxKB*9/10 || count > 1000 {
-		c.Cleanup()
+		_, _ = c.Cleanup()
 	}
 }
 
@@ -275,7 +275,7 @@ func (c *CommunityCache) updateMeta(id string, entry *CacheEntry) {
 	} else {
 		meta.Patterns[id] = entry
 	}
-	c.saveMeta(meta)
+	_ = c.saveMeta(meta)
 }
 
 // DefaultCommunityCache creates a cache with default settings.

--- a/internal/cache/memory_cache_test.go
+++ b/internal/cache/memory_cache_test.go
@@ -6,8 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/mur-run/mur-core/internal/core/pattern"
 	"gopkg.in/yaml.v3"
+
+	"github.com/mur-run/mur-core/internal/core/pattern"
 )
 
 func TestMemoryCacheDisabled(t *testing.T) {

--- a/internal/cache/pattern_cache.go
+++ b/internal/cache/pattern_cache.go
@@ -8,8 +8,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mur-run/mur-core/internal/core/pattern"
 	"gopkg.in/yaml.v3"
+
+	"github.com/mur-run/mur-core/internal/core/pattern"
 )
 
 // PatternCache holds all patterns in memory with an inverted tag index.

--- a/internal/cache/pattern_cache_test.go
+++ b/internal/cache/pattern_cache_test.go
@@ -5,8 +5,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/mur-run/mur-core/internal/core/pattern"
 	"gopkg.in/yaml.v3"
+
+	"github.com/mur-run/mur-core/internal/core/pattern"
 )
 
 // writeTestPattern writes a pattern YAML file to dir.

--- a/internal/cloud/browser_oauth.go
+++ b/internal/cloud/browser_oauth.go
@@ -162,7 +162,7 @@ func BrowserOAuthLogin(client *Client) error {
 	// Shutdown server
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer shutdownCancel()
-	srv.Shutdown(shutdownCtx)
+	_ = srv.Shutdown(shutdownCtx)
 
 	return loginErr
 }

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -150,7 +150,7 @@ func (c *Client) LoginWithAPIKey(apiKey string) error {
 	user, err := c.Me()
 	if err != nil {
 		// Clear the invalid key
-		c.authStore.Clear()
+		_ = c.authStore.Clear()
 		return err
 	}
 
@@ -506,19 +506,19 @@ func (c *Client) GetCommunityFeatured(limit int) (*CommunityListResponse, error)
 
 // UserProfile represents a user's public profile
 type UserProfile struct {
-	ID           string            `json:"id"`
-	Name         string            `json:"name"`
-	Login        string            `json:"login,omitempty"`
-	Bio          string            `json:"bio,omitempty"`
-	Website      string            `json:"website,omitempty"`
-	GitHub       string            `json:"github,omitempty"`
-	Twitter      string            `json:"twitter,omitempty"`
-	Plan         string            `json:"plan"`
-	PatternCount int               `json:"pattern_count"`
-	TotalCopies  int               `json:"total_copies"`
-	TotalStars   int               `json:"total_stars"`
+	ID           string             `json:"id"`
+	Name         string             `json:"name"`
+	Login        string             `json:"login,omitempty"`
+	Bio          string             `json:"bio,omitempty"`
+	Website      string             `json:"website,omitempty"`
+	GitHub       string             `json:"github,omitempty"`
+	Twitter      string             `json:"twitter,omitempty"`
+	Plan         string             `json:"plan"`
+	PatternCount int                `json:"pattern_count"`
+	TotalCopies  int                `json:"total_copies"`
+	TotalStars   int                `json:"total_stars"`
 	Patterns     []CommunityPattern `json:"patterns"`
-	JoinedAt     string            `json:"joined_at"`
+	JoinedAt     string             `json:"joined_at"`
 }
 
 // GetUserProfile returns a user's public profile
@@ -598,12 +598,12 @@ func (c *Client) SearchCommunity(query string, limit int) (*CommunityListRespons
 func (c *Client) SearchCommunityWithTech(query string, techStack []string, limit int) (*CommunityListResponse, error) {
 	var resp CommunityListResponse
 	path := fmt.Sprintf("/api/v1/core/community/patterns/search?q=%s&limit=%d", query, limit)
-	
+
 	// Add tech stack filter
 	if len(techStack) > 0 {
 		path += "&tech=" + strings.Join(techStack, ",")
 	}
-	
+
 	if err := c.get(path, &resp); err != nil {
 		return nil, err
 	}

--- a/internal/cloud/device.go
+++ b/internal/cloud/device.go
@@ -45,8 +45,8 @@ func getOrCreateDeviceID() string {
 	id := generateDeviceID()
 
 	// Save for future use
-	os.MkdirAll(configDir, 0700)
-	os.WriteFile(deviceFile, []byte(id), 0600)
+	_ = os.MkdirAll(configDir, 0700)
+	_ = os.WriteFile(deviceFile, []byte(id), 0600)
 
 	return id
 }
@@ -73,11 +73,7 @@ func getDeviceName() string {
 		return "Unknown Device"
 	}
 
-	// Try to get a nicer name on macOS
-	if runtime.GOOS == "darwin" {
-		// Try scutil --get ComputerName
-		// For now, just use hostname
-	}
+	// TODO: Try to get a nicer name on macOS via scutil --get ComputerName
 
 	return hostname
 }
@@ -90,12 +86,12 @@ func getMurConfigDir() string {
 
 // Device represents a device from the server
 type Device struct {
-	ID           string    `json:"id"`
-	DeviceID     string    `json:"device_id"`
-	DeviceName   string    `json:"device_name"`
-	OS           string    `json:"os"`
-	LastActiveAt string    `json:"last_active_at"`
-	IsActive     bool      `json:"is_active"`
+	ID           string `json:"id"`
+	DeviceID     string `json:"device_id"`
+	DeviceName   string `json:"device_name"`
+	OS           string `json:"os"`
+	LastActiveAt string `json:"last_active_at"`
+	IsActive     bool   `json:"is_active"`
 }
 
 // DeviceListResponse is the response from /devices

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,11 +28,11 @@ type Config struct {
 	Team          TeamConfig          `yaml:"team"`
 	Server        ServerConfig        `yaml:"server"`
 	Notifications NotificationsConfig `yaml:"notifications"`
-	TechStack     []string            `yaml:"tech_stack"` // User's tech stack for filtering (e.g., ["swift", "go", "docker"])
-	Cache         CacheConfig         `yaml:"cache"`      // Local cache settings
-	Community      CommunityConfig      `yaml:"community"`      // Community sharing settings
-	Privacy        PrivacyConfig        `yaml:"privacy"`        // Privacy & PII protection settings
-	Consolidation  ConsolidationConfig  `yaml:"consolidation"`  // Pattern consolidation settings
+	TechStack     []string            `yaml:"tech_stack"`    // User's tech stack for filtering (e.g., ["swift", "go", "docker"])
+	Cache         CacheConfig         `yaml:"cache"`         // Local cache settings
+	Community     CommunityConfig     `yaml:"community"`     // Community sharing settings
+	Privacy       PrivacyConfig       `yaml:"privacy"`       // Privacy & PII protection settings
+	Consolidation ConsolidationConfig `yaml:"consolidation"` // Pattern consolidation settings
 }
 
 // CacheConfig represents local cache settings for community patterns.
@@ -42,9 +42,9 @@ type CacheConfig struct {
 
 // CommunityConfig represents community sharing settings.
 type CommunityConfig struct {
-	ShareEnabled    bool `yaml:"share_enabled"`     // Enable community sharing
+	ShareEnabled    bool `yaml:"share_enabled"`      // Enable community sharing
 	AutoShareOnPush bool `yaml:"auto_share_on_push"` // Auto-share when pushing
-	ShareExtracted  bool `yaml:"share_extracted"`   // Share extracted patterns (may contain secrets)
+	ShareExtracted  bool `yaml:"share_extracted"`    // Share extracted patterns (may contain secrets)
 }
 
 // DefaultCommunityConfig returns default community settings.
@@ -58,10 +58,10 @@ func DefaultCommunityConfig() CommunityConfig {
 
 // PrivacyConfig represents privacy and PII protection settings.
 type PrivacyConfig struct {
-	RedactTerms            []string                      `yaml:"redact_terms"`             // Terms to always redact
-	Replacements           map[string]string             `yaml:"replacements"`             // Custom replacement mappings
-	AutoDetect             AutoDetectConfig              `yaml:"auto_detect"`              // Auto-detection toggles
-	SemanticAnonymization  SemanticAnonymizationConfig   `yaml:"semantic_anonymization"`   // LLM-based anonymization
+	RedactTerms           []string                    `yaml:"redact_terms"`           // Terms to always redact
+	Replacements          map[string]string           `yaml:"replacements"`           // Custom replacement mappings
+	AutoDetect            AutoDetectConfig            `yaml:"auto_detect"`            // Auto-detection toggles
+	SemanticAnonymization SemanticAnonymizationConfig `yaml:"semantic_anonymization"` // LLM-based anonymization
 }
 
 // SemanticAnonymizationConfig controls LLM-based semantic anonymization.
@@ -76,10 +76,10 @@ type SemanticAnonymizationConfig struct {
 // AutoDetectConfig controls which PII types are auto-detected.
 type AutoDetectConfig struct {
 	Emails       *bool `yaml:"emails"`        // Detect email addresses (default: true)
-	InternalIPs  *bool `yaml:"internal_ips"`   // Detect internal IPs (default: true)
-	FilePaths    *bool `yaml:"file_paths"`     // Detect user file paths (default: true)
-	PhoneNumbers *bool `yaml:"phone_numbers"`  // Detect phone numbers (default: true)
-	InternalURLs *bool `yaml:"internal_urls"`  // Detect internal URLs (default: true)
+	InternalIPs  *bool `yaml:"internal_ips"`  // Detect internal IPs (default: true)
+	FilePaths    *bool `yaml:"file_paths"`    // Detect user file paths (default: true)
+	PhoneNumbers *bool `yaml:"phone_numbers"` // Detect phone numbers (default: true)
+	InternalURLs *bool `yaml:"internal_urls"` // Detect internal URLs (default: true)
 }
 
 // IsEmailsEnabled returns whether email detection is enabled (default: true).
@@ -145,10 +145,10 @@ func DefaultPrivacyConfig() PrivacyConfig {
 // ConsolidationConfig represents pattern consolidation settings.
 type ConsolidationConfig struct {
 	Enabled              bool    `yaml:"enabled"`
-	Schedule             string  `yaml:"schedule"`                // daily | weekly | monthly
+	Schedule             string  `yaml:"schedule"` // daily | weekly | monthly
 	AutoArchive          bool    `yaml:"auto_archive"`
-	AutoMerge            string  `yaml:"auto_merge"`              // off | keep-best | llm-merge
-	MergeThreshold       float64 `yaml:"merge_threshold"`         // cosine similarity threshold
+	AutoMerge            string  `yaml:"auto_merge"`      // off | keep-best | llm-merge
+	MergeThreshold       float64 `yaml:"merge_threshold"` // cosine similarity threshold
 	DecayHalfLifeDays    int     `yaml:"decay_half_life_days"`
 	GracePeriodDays      int     `yaml:"grace_period_days"`
 	MinPatternsBeforeRun int     `yaml:"min_patterns_before_run"`
@@ -291,13 +291,13 @@ type SyncConfig struct {
 
 // SearchConfig represents semantic search settings.
 type SearchConfig struct {
-	Enabled    *bool  `yaml:"enabled"`     // nil = use default (true)
-	Provider   string `yaml:"provider"`    // ollama | openai | none
-	Model      string `yaml:"model"`       // embedding model name
-	OllamaURL  string `yaml:"ollama_url"`  // Ollama API URL
-	TopK       int    `yaml:"top_k"`       // default number of results
-	MinScore   float64 `yaml:"min_score"`  // minimum similarity score
-	AutoInject *bool  `yaml:"auto_inject"` // auto-inject to prompt via hooks (default: true)
+	Enabled    *bool   `yaml:"enabled"`     // nil = use default (true)
+	Provider   string  `yaml:"provider"`    // ollama | openai | none
+	Model      string  `yaml:"model"`       // embedding model name
+	OllamaURL  string  `yaml:"ollama_url"`  // Ollama API URL
+	TopK       int     `yaml:"top_k"`       // default number of results
+	MinScore   float64 `yaml:"min_score"`   // minimum similarity score
+	AutoInject *bool   `yaml:"auto_inject"` // auto-inject to prompt via hooks (default: true)
 }
 
 // IsEnabled returns whether search is enabled (default: true).

--- a/internal/consolidate/conflict.go
+++ b/internal/consolidate/conflict.go
@@ -12,7 +12,7 @@ type ConflictType string
 const (
 	ConflictContradiction ConflictType = "contradiction" // opposite advice
 	ConflictOutdated      ConflictType = "outdated"      // one supersedes the other
-	ConflictScope         ConflictType = "scope"          // different contexts that may confuse
+	ConflictScope         ConflictType = "scope"         // different contexts that may confuse
 )
 
 // Conflict represents a detected conflict between two patterns.

--- a/internal/consolidate/consolidate.go
+++ b/internal/consolidate/consolidate.go
@@ -22,18 +22,18 @@ const (
 
 // ConsolidationReport holds the results of a consolidation run.
 type ConsolidationReport struct {
-	Timestamp       time.Time       `json:"timestamp"`
-	Mode            Mode            `json:"mode"`
-	TotalPatterns   int             `json:"total_patterns"`
-	HealthScores    []HealthScore   `json:"health_scores"`
-	MergeProposals  []MergeProposal `json:"merge_proposals"`
-	Conflicts       []Conflict      `json:"conflicts"`
-	ActionsApplied  int             `json:"actions_applied"`
-	PatternsKept    int             `json:"patterns_kept"`
-	PatternsArchived int            `json:"patterns_archived"`
-	PatternsMerged  int             `json:"patterns_merged"`
-	PatternsUpdated int             `json:"patterns_updated"`
-	Duration        time.Duration   `json:"duration"`
+	Timestamp        time.Time       `json:"timestamp"`
+	Mode             Mode            `json:"mode"`
+	TotalPatterns    int             `json:"total_patterns"`
+	HealthScores     []HealthScore   `json:"health_scores"`
+	MergeProposals   []MergeProposal `json:"merge_proposals"`
+	Conflicts        []Conflict      `json:"conflicts"`
+	ActionsApplied   int             `json:"actions_applied"`
+	PatternsKept     int             `json:"patterns_kept"`
+	PatternsArchived int             `json:"patterns_archived"`
+	PatternsMerged   int             `json:"patterns_merged"`
+	PatternsUpdated  int             `json:"patterns_updated"`
+	Duration         time.Duration   `json:"duration"`
 }
 
 // Consolidator orchestrates the pattern consolidation process.
@@ -205,9 +205,7 @@ func (c *Consolidator) applyActions(report *ConsolidationReport, patterns []*pat
 			// Update the keeper with relations
 			keeper, ok := patternMap[proposal.KeepID]
 			if ok {
-				for _, removeID := range proposal.RemoveIDs {
-					keeper.Relations.Related = append(keeper.Relations.Related, removeID)
-				}
+				keeper.Relations.Related = append(keeper.Relations.Related, proposal.RemoveIDs...)
 				keeper.Health.LastConsolidated = &now
 				_ = c.store.Update(keeper)
 			}

--- a/internal/consolidate/consolidate_test.go
+++ b/internal/consolidate/consolidate_test.go
@@ -43,7 +43,7 @@ func TestHealthScore_FreshnessDecay(t *testing.T) {
 
 	now := scorer.now
 	recent := now.Add(-1 * 24 * time.Hour) // 1 day ago
-	old := now.Add(-180 * 24 * time.Hour)   // 180 days ago (2 half-lives)
+	old := now.Add(-180 * 24 * time.Hour)  // 180 days ago (2 half-lives)
 
 	pRecent := makePattern("p1", "recent", recent, 5, &recent)
 	pOld := makePattern("p2", "old", old, 5, &old)
@@ -101,10 +101,10 @@ func TestHealthScore_Engagement(t *testing.T) {
 
 	now := time.Now()
 	tests := []struct {
-		name     string
-		usage    int
-		wantMin  float64
-		wantMax  float64
+		name    string
+		usage   int
+		wantMin float64
+		wantMax float64
 	}{
 		{"zero usage", 0, 0.0, 0.15},
 		{"low usage", 3, 0.2, 0.4},
@@ -128,10 +128,10 @@ func TestHealthScore_Quality(t *testing.T) {
 	cfg := defaultCfg()
 
 	tests := []struct {
-		name     string
-		helpful  int
+		name      string
+		helpful   int
 		unhelpful int
-		want     float64
+		want      float64
 	}{
 		{"no feedback", 0, 0, 0.5},
 		{"all helpful", 10, 0, 1.0},

--- a/internal/core/analytics/tracker.go
+++ b/internal/core/analytics/tracker.go
@@ -15,10 +15,10 @@ import (
 type EventType string
 
 const (
-	EventSearch    EventType = "search"    // Pattern found via semantic search
-	EventInject    EventType = "inject"    // Pattern injected via sync/hooks
-	EventView      EventType = "view"      // Pattern viewed in dashboard/CLI
-	EventFeedback  EventType = "feedback"  // User feedback on pattern
+	EventSearch   EventType = "search"   // Pattern found via semantic search
+	EventInject   EventType = "inject"   // Pattern injected via sync/hooks
+	EventView     EventType = "view"     // Pattern viewed in dashboard/CLI
+	EventFeedback EventType = "feedback" // User feedback on pattern
 )
 
 // Event represents a single pattern usage event.
@@ -27,10 +27,10 @@ type Event struct {
 	PatternName string    `json:"pattern_name"`
 	EventType   EventType `json:"event_type"`
 	Timestamp   time.Time `json:"timestamp"`
-	Score       float64   `json:"score,omitempty"`      // For search events
-	Source      string    `json:"source,omitempty"`     // hook, cli, dashboard
-	Helpful     *bool     `json:"helpful,omitempty"`    // For feedback events
-	Context     string    `json:"context,omitempty"`    // Query or prompt snippet
+	Score       float64   `json:"score,omitempty"`   // For search events
+	Source      string    `json:"source,omitempty"`  // hook, cli, dashboard
+	Helpful     *bool     `json:"helpful,omitempty"` // For feedback events
+	Context     string    `json:"context,omitempty"` // Query or prompt snippet
 }
 
 // PatternStats aggregates usage stats for a pattern.

--- a/internal/core/classifier/classifier.go
+++ b/internal/core/classifier/classifier.go
@@ -205,10 +205,10 @@ func (k *KeywordClassifier) Classify(input ClassifyInput) []DomainScore {
 func defaultDomainKeywords() map[string][]string {
 	return map[string][]string{
 		// Programming languages
-		"swift": {"swift", "swiftui", "uikit", "appkit", "xctest", "xcode", "@State", "@Published", "Sendable"},
-		"go":    {"golang", "go ", "goroutine", "chan ", "defer", "go.mod", "go.sum"},
-		"rust":  {"rust", "cargo", "rustc", "impl ", "fn ", "mut ", "unwrap"},
-		"python": {"python", "pip", "pytest", "django", "flask", "numpy", "pandas", "__init__"},
+		"swift":      {"swift", "swiftui", "uikit", "appkit", "xctest", "xcode", "@State", "@Published", "Sendable"},
+		"go":         {"golang", "go ", "goroutine", "chan ", "defer", "go.mod", "go.sum"},
+		"rust":       {"rust", "cargo", "rustc", "impl ", "fn ", "mut ", "unwrap"},
+		"python":     {"python", "pip", "pytest", "django", "flask", "numpy", "pandas", "__init__"},
 		"typescript": {"typescript", "tsx", "interface ", "type ", "as const"},
 		"javascript": {"javascript", "nodejs", "npm", "yarn", "react", "vue", "angular"},
 
@@ -219,9 +219,9 @@ func defaultDomainKeywords() map[string][]string {
 		"backend": {"api", "rest", "graphql", "grpc", "microservice", "endpoint"},
 
 		// DevOps/infrastructure
-		"devops":     {"docker", "kubernetes", "k8s", "helm", "terraform", "ansible", "ci/cd", "pipeline"},
-		"database":   {"sql", "postgres", "mysql", "mongodb", "redis", "database", "query", "migration"},
-		"cloud":      {"aws", "azure", "gcp", "cloud", "lambda", "s3", "ec2"},
+		"devops":   {"docker", "kubernetes", "k8s", "helm", "terraform", "ansible", "ci/cd", "pipeline"},
+		"database": {"sql", "postgres", "mysql", "mongodb", "redis", "database", "query", "migration"},
+		"cloud":    {"aws", "azure", "gcp", "cloud", "lambda", "s3", "ec2"},
 
 		// Development practices
 		"testing":      {"test", "unit test", "integration", "mock", "stub", "coverage", "tdd"},
@@ -232,8 +232,8 @@ func defaultDomainKeywords() map[string][]string {
 		"performance":  {"performance", "optimize", "cache", "latency", "memory", "cpu", "profil"},
 
 		// AI/ML
-		"ai":  {"ai", "llm", "gpt", "claude", "gemini", "prompt", "embedding", "vector"},
-		"ml":  {"machine learning", "model", "training", "inference", "neural", "tensorflow", "pytorch"},
+		"ai": {"ai", "llm", "gpt", "claude", "gemini", "prompt", "embedding", "vector"},
+		"ml": {"machine learning", "model", "training", "inference", "neural", "tensorflow", "pytorch"},
 
 		// Business/other
 		"documentation": {"document", "readme", "changelog", "api doc", "swagger", "openapi"},
@@ -329,8 +329,8 @@ func defaultFilePatterns() map[string][]string {
 		"javascript": {"*.js", "*.jsx", "package.json"},
 
 		// Web
-		"web":  {"*.html", "*.css", "*.scss", "*.sass", "*.less"},
-		"vue":  {"*.vue"},
+		"web":   {"*.html", "*.css", "*.scss", "*.sass", "*.less"},
+		"vue":   {"*.vue"},
 		"react": {"*.jsx", "*.tsx"},
 
 		// Config/DevOps

--- a/internal/core/classifier/retriever.go
+++ b/internal/core/classifier/retriever.go
@@ -9,10 +9,10 @@ import (
 
 // PatternMatch represents a pattern with its relevance score.
 type PatternMatch struct {
-	Pattern   pattern.Pattern
-	Score     float64
-	Reasons   []string
-	Domains   []string
+	Pattern pattern.Pattern
+	Score   float64
+	Reasons []string
+	Domains []string
 }
 
 // Retriever finds relevant patterns based on classification.

--- a/internal/core/embed/indexer.go
+++ b/internal/core/embed/indexer.go
@@ -59,9 +59,7 @@ func NewPatternIndexer(cfg *config.Config) (*PatternIndexer, error) {
 	}
 
 	cache := NewCache(cacheDir, embedder)
-	if err := cache.Load(); err != nil {
-		// Ignore load errors, start with empty cache
-	}
+	_ = cache.Load() // Ignore load errors, start with empty cache
 
 	return &PatternIndexer{
 		cfg:      cfg,

--- a/internal/core/inject/inject.go
+++ b/internal/core/inject/inject.go
@@ -59,10 +59,10 @@ type ProjectContext struct {
 type Injector struct {
 	store            *pattern.Store
 	classifier       *classifier.HybridClassifier
-	searcher         *embed.PatternSearcher    // Optional semantic search
-	cache            *cache.MemoryCache        // Optional in-process cache
+	searcher         *embed.PatternSearcher     // Optional semantic search
+	cache            *cache.MemoryCache         // Optional in-process cache
 	injectionScanner *security.InjectionScanner // Injection scanner
-	auditLogger      *audit.Logger             // Optional audit logger
+	auditLogger      *audit.Logger              // Optional audit logger
 }
 
 // NewInjector creates a new pattern injector.
@@ -167,8 +167,8 @@ func (inj *Injector) Inject(prompt string, workDir string) (*InjectionResult, er
 // detectContext analyzes the working directory to detect project context.
 func (inj *Injector) detectContext(workDir string) *ProjectContext {
 	ctx := &ProjectContext{
-		RootDir:   workDir,
-		Languages: []string{},
+		RootDir:    workDir,
+		Languages:  []string{},
 		Frameworks: []string{},
 	}
 

--- a/internal/core/pattern/lifecycle.go
+++ b/internal/core/pattern/lifecycle.go
@@ -67,10 +67,10 @@ type LifecycleAction struct {
 type ActionType string
 
 const (
-	ActionDeprecate ActionType = "deprecate"
-	ActionArchive   ActionType = "archive"
+	ActionDeprecate  ActionType = "deprecate"
+	ActionArchive    ActionType = "archive"
 	ActionReactivate ActionType = "reactivate"
-	ActionKeep      ActionType = "keep"
+	ActionKeep       ActionType = "keep"
 )
 
 // LifecycleReport summarizes lifecycle evaluation.

--- a/internal/core/pattern/migrate.go
+++ b/internal/core/pattern/migrate.go
@@ -26,13 +26,13 @@ type V1Pattern struct {
 
 // MigrationResult holds the result of migrating patterns.
 type MigrationResult struct {
-	TotalPatterns   int
-	MigratedCount   int
-	SkippedCount    int
-	ErrorCount      int
-	Errors          []MigrationError
-	MigratedFiles   []string
-	BackupDir       string
+	TotalPatterns int
+	MigratedCount int
+	SkippedCount  int
+	ErrorCount    int
+	Errors        []MigrationError
+	MigratedFiles []string
+	BackupDir     string
 }
 
 // MigrationError represents an error during migration.

--- a/internal/core/pattern/store.go
+++ b/internal/core/pattern/store.go
@@ -14,7 +14,7 @@ import (
 
 // Store provides pattern storage operations.
 type Store struct {
-	baseDir  string
+	baseDir   string
 	localOnly bool // when true, don't fall back to ~/.mur/repo/patterns/
 }
 

--- a/internal/core/suggest/extractor.go
+++ b/internal/core/suggest/extractor.go
@@ -210,22 +210,22 @@ func (e *Extractor) extractBlocks(path string) ([]contentBlock, error) {
 	// Extract sections with headers (simplified regex without lookahead)
 	sectionRe := regexp.MustCompile(`(?m)^(#{1,3})\s+(.+)\n`)
 	sectionMatches := sectionRe.FindAllStringSubmatchIndex(content, -1)
-	
+
 	for i := 0; i < len(sectionMatches); i++ {
 		headerStart := sectionMatches[i][0]
 		headerEnd := sectionMatches[i][1]
 		titleStart := sectionMatches[i][4]
 		titleEnd := sectionMatches[i][5]
-		
+
 		// Find content end (next header or EOF)
 		contentEnd := len(content)
 		if i+1 < len(sectionMatches) {
 			contentEnd = sectionMatches[i+1][0]
 		}
-		
+
 		title := content[titleStart:titleEnd]
 		sectionContent := content[headerEnd:contentEnd]
-		
+
 		if len(sectionContent) >= e.cfg.MinContentLength {
 			blocks = append(blocks, contentBlock{
 				Content:  strings.TrimSpace(sectionContent),

--- a/internal/hooks/auggie.go
+++ b/internal/hooks/auggie.go
@@ -84,7 +84,7 @@ func InstallAuggieHooks() error {
 	if _, err := os.Stat(settingsPath); err == nil {
 		backupPath := settingsPath + ".backup"
 		if data, err := os.ReadFile(settingsPath); err == nil {
-			os.WriteFile(backupPath, data, 0644)
+			_ = os.WriteFile(backupPath, data, 0644)
 		}
 	}
 

--- a/internal/hooks/claudecode.go
+++ b/internal/hooks/claudecode.go
@@ -16,10 +16,10 @@ type ClaudeCodeHook struct {
 
 // ClaudeCodeHooks represents the hooks configuration.
 type ClaudeCodeHooks struct {
-	PreToolUse map[string][]ClaudeCodeHook `json:"PreToolUse,omitempty"`
-	PostToolUse map[string][]ClaudeCodeHook `json:"PostToolUse,omitempty"`
-	UserPromptSubmit []ClaudeCodeHook `json:"UserPromptSubmit,omitempty"`
-	Stop []ClaudeCodeHook `json:"Stop,omitempty"`
+	PreToolUse       map[string][]ClaudeCodeHook `json:"PreToolUse,omitempty"`
+	PostToolUse      map[string][]ClaudeCodeHook `json:"PostToolUse,omitempty"`
+	UserPromptSubmit []ClaudeCodeHook            `json:"UserPromptSubmit,omitempty"`
+	Stop             []ClaudeCodeHook            `json:"Stop,omitempty"`
 }
 
 // ClaudeCodeSettings represents the Claude Code settings file.

--- a/internal/hooks/copilot.go
+++ b/internal/hooks/copilot.go
@@ -17,7 +17,7 @@ type CopilotHookDef struct {
 
 // CopilotHooksConfig defines the hooks configuration for GitHub Copilot.
 type CopilotHooksConfig struct {
-	Version int                        `json:"version"`
+	Version int                         `json:"version"`
 	Hooks   map[string][]CopilotHookDef `json:"hooks"`
 }
 

--- a/internal/learn/cross_cli.go
+++ b/internal/learn/cross_cli.go
@@ -18,8 +18,8 @@ import (
 // CLISource represents an AI CLI tool as a learning source.
 type CLISource struct {
 	Name        string
-	SessionDir  string   // Path to session/history directory
-	FilePattern string   // Glob pattern for session files
+	SessionDir  string // Path to session/history directory
+	FilePattern string // Glob pattern for session files
 	Parser      SessionParser
 }
 
@@ -30,11 +30,11 @@ type SessionParser interface {
 
 // SessionEntry represents a single exchange in a session.
 type SessionEntry struct {
-	Role      string    // "user" or "assistant"
+	Role      string // "user" or "assistant"
 	Content   string
 	Timestamp time.Time
-	Tool      string    // Which tool was used (if any)
-	Success   bool      // Whether the action succeeded
+	Tool      string // Which tool was used (if any)
+	Success   bool   // Whether the action succeeded
 }
 
 // DefaultCLISources returns the known CLI sources.
@@ -252,10 +252,10 @@ func detectTopic(entries []SessionEntry) string {
 			content := strings.ToLower(e.Content)
 
 			topics := map[string][]string{
-				"debugging":    {"bug", "error", "fix", "issue", "problem"},
-				"refactoring":  {"refactor", "clean", "improve", "optimize"},
-				"testing":      {"test", "spec", "coverage"},
-				"feature":      {"add", "implement", "create", "build"},
+				"debugging":     {"bug", "error", "fix", "issue", "problem"},
+				"refactoring":   {"refactor", "clean", "improve", "optimize"},
+				"testing":       {"test", "spec", "coverage"},
+				"feature":       {"add", "implement", "create", "build"},
 				"documentation": {"doc", "readme", "comment", "explain"},
 			}
 

--- a/internal/learn/extract_test.go
+++ b/internal/learn/extract_test.go
@@ -74,8 +74,8 @@ func TestIsValidPatternName(t *testing.T) {
 		{"wait-changed-line", false},
 		{"now-also-need", false},
 		{"see-unloadplist-calls", false},
-		{"abc", false},  // too short
-		{"ab", false},   // too short
+		{"abc", false}, // too short
+		{"ab", false},  // too short
 	}
 
 	for _, tt := range tests {

--- a/internal/learn/llm_extract.go
+++ b/internal/learn/llm_extract.go
@@ -15,10 +15,10 @@ import (
 type LLMProvider string
 
 const (
-	LLMOllama   LLMProvider = "ollama"
-	LLMClaude   LLMProvider = "claude"
-	LLMOpenAI   LLMProvider = "openai"   // OpenAI-compatible APIs
-	LLMGemini   LLMProvider = "gemini"
+	LLMOllama LLMProvider = "ollama"
+	LLMClaude LLMProvider = "claude"
+	LLMOpenAI LLMProvider = "openai" // OpenAI-compatible APIs
+	LLMGemini LLMProvider = "gemini"
 )
 
 // LLMExtractOptions configures LLM-based extraction.
@@ -490,7 +490,7 @@ func callGemini(transcript string, opts LLMExtractOptions) (string, error) {
 			},
 		},
 		"generationConfig": map[string]interface{}{
-			"temperature": 0.3,
+			"temperature":     0.3,
 			"maxOutputTokens": 4096,
 		},
 	}

--- a/internal/learn/quality.go
+++ b/internal/learn/quality.go
@@ -16,12 +16,12 @@ type SessionQuality struct {
 
 // ExtractionConfig holds thresholds for quality filtering.
 type ExtractionConfig struct {
-	MinToolUses          int      // Minimum tool uses required
-	MinTurns             int      // Minimum conversation turns
-	MaxAssistantRatio    float64  // Max ratio of assistant content
-	MinContentLength     int      // Minimum pattern content length
-	RequireProblemSolve  bool     // Require problem/solution structure
-	RejectKeywords       []string // Keywords that indicate generic content
+	MinToolUses         int      // Minimum tool uses required
+	MinTurns            int      // Minimum conversation turns
+	MaxAssistantRatio   float64  // Max ratio of assistant content
+	MinContentLength    int      // Minimum pattern content length
+	RequireProblemSolve bool     // Require problem/solution structure
+	RejectKeywords      []string // Keywords that indicate generic content
 }
 
 // DefaultExtractionConfig returns sensible defaults.

--- a/internal/learn/session.go
+++ b/internal/learn/session.go
@@ -43,12 +43,6 @@ type messageContent struct {
 	Content json.RawMessage `json:"content"`
 }
 
-// contentBlock represents a content block (text or tool_use).
-type contentBlock struct {
-	Type string `json:"type"`
-	Text string `json:"text,omitempty"`
-}
-
 // ClaudeProjectsDir returns the path to ~/.claude/projects/
 func ClaudeProjectsDir() (string, error) {
 	home, err := os.UserHomeDir()

--- a/internal/learn/sync_v2.go
+++ b/internal/learn/sync_v2.go
@@ -36,8 +36,8 @@ func SyncPatternsV2() ([]SyncResult, error) {
 
 	// Sync to all CLI tools
 	cliTargets := []struct {
-		name    string
-		syncFn  func(string, []pattern.Pattern) SyncResult
+		name   string
+		syncFn func(string, []pattern.Pattern) SyncResult
 	}{
 		{"Claude Code", syncToClaudeCodeV2},
 		{"Gemini CLI", syncToGeminiCLIV2},

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -20,10 +20,10 @@ type Options struct {
 
 // Event types for notifications.
 const (
-	EventPatternAdded     = "pattern_added"
+	EventPatternAdded      = "pattern_added"
 	EventPatternsExtracted = "patterns_extracted"
-	EventPRCreated        = "pr_created"
-	EventTest             = "test"
+	EventPRCreated         = "pr_created"
+	EventTest              = "test"
 )
 
 // Notify sends a notification to all configured channels.

--- a/internal/notify/system.go
+++ b/internal/notify/system.go
@@ -55,10 +55,10 @@ func SystemNotify(title, message string, level Level) error {
 			"-sound", sound,
 			"-group", "mur",
 		}
-		
+
 		// Add sender for icon
 		args = append(args, "-sender", "com.apple.Terminal")
-		
+
 		cmd := exec.Command("terminal-notifier", args...)
 		if err := cmd.Run(); err == nil {
 			return nil

--- a/internal/security/scanner.go
+++ b/internal/security/scanner.go
@@ -10,7 +10,7 @@ import (
 type Finding struct {
 	Type    string `json:"type"`
 	Line    int    `json:"line"`
-	Match   string `json:"match"`   // redacted
+	Match   string `json:"match"` // redacted
 	Message string `json:"message"`
 }
 

--- a/internal/sync/patterns_sync.go
+++ b/internal/sync/patterns_sync.go
@@ -106,10 +106,10 @@ func looksLikeMurPattern(content string) bool {
 
 // PatternTarget defines where patterns are synced to for each CLI.
 type PatternTarget struct {
-	Name       string
-	SkillsDir  string // relative to home
-	FileName   string // the skill file name
-	Format     string // "markdown" or "yaml"
+	Name      string
+	SkillsDir string // relative to home
+	FileName  string // the skill file name
+	Format    string // "markdown" or "yaml"
 }
 
 // DefaultPatternTargets returns all supported CLI targets.


### PR DESCRIPTION
Resolve all ~50 golangci-lint errors across the codebase:

## Changes

- **errcheck** (~40): Added `_ =` for unchecked error return values where errors are intentionally ignored
- **unused** (2): Removed unused type `contentBlock` in `internal/learn/session.go` and func `fetchRawContent` in `cmd/mur/cmd/import.go`
- **gofmt/goimports** (all files): Formatted with `gofmt -s` and `goimports -local github.com/mur-run/mur-core`
- **gosimple** (3): Replaced manual loops with `append(tags, p.Tags.Confirmed...)`, simplified `fmt.Sprintf` to `string()`
- **ineffassign** (1): Removed ineffectual assignment to `cliOnly` in sync.go
- **staticcheck** (3): Removed unused `preview` variable, replaced empty if-branch with TODO comment, simplified error ignore

## Verification

- `go build ./...` passes
- `golangci-lint run --timeout=5m` returns zero errors